### PR TITLE
feat: hardening kernel and network

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 #########################################
 # Global role parts activation variables
 openssh_config: true
+kernel_hardening: true
+network_hardening: true
 
 #########################################
 # OpenSSH tuning variables
@@ -104,3 +106,56 @@ sshd_enable_sftp: true
 #      - 'PermitRootLogin yes'
 
 #########################################
+# Kernel hardening variables
+# @var hard_kernel_self_protection: 1 # Define kernel protection kernel.kptr_restrict value
+hard_kernel_self_protection: 1
+# @var hard_kernel_dmesg_restrict: 1 # Restrict dmesg view to CAP_SYSLOG capability
+hard_kernel_dmesg_restrict: 1
+# @var hard_kernel_disable_unpriv_bpf: 1 # Restrict BPF calls to CAP_BPF/CAP_SYS_ADMIN capability
+hard_kernel_disable_unpriv_bpf: 1
+# @var hard_net_disable_unpriv_bpf: 2 # Restrict network BPF to CAP_BPF/CAP_SYS_ADMIN capability
+hard_net_disable_unpriv_bpf: 2
+# @var hard_dev_enable_ldisc_autoload: 0 # Restrict line discipline to CAP_SYS_MODULE capability
+hard_dev_enable_ldisc_autoload: 0
+# @var hard_vm_disable_unpriv_userfaultfd: 0 # Restrict userfaultfd syscall to CAP_SYS_PTRACES
+hard_vm_enable_unpriv_userfaultfd: 0
+# @var hard_kernel_disable_kexec: 1 # Disable kexec possibility
+hard_kernel_disable_kexec: 1
+# @var hard_kernel_sysrq: 4 # Setup sysrq to give keyboard control only
+hard_kernel_sysrq: 4
+# @var hard_net_tcp_syncookies: 1 # Setup TCP cookies to prevent SYN flood attack
+hard_net_tcp_syncookies: 1
+# @var hard_net_tcp_rfc1337: 1 # Force drop connections in TIME-WAIT status
+hard_net_tcp_rfc1337: 1
+# @var hard_net_pkt_validation: 1 # Force packet source validation to protect of IP spoofing
+hard_net_pkt_validation: 1
+# @var hard_net_accept_icmp_redirect: 0 # Allow ICMP redirect acceptance and sending
+hard_net_accept_icmp_redirect: 0
+# @var hard_net_ignore_icmp_echo: 0 # Disallow ICMP echo request from all sources
+hard_net_ignore_icmp_echo: 0
+# @var hard_net_allow_source_routing: 0 # Allow source routing
+hard_net_allow_source_routing: 0
+# @var hard_net_allow_ra: 0 # Allow IPv6 router advertisement
+hard_net_allow_ra: 0
+# @var hard_net_allow_extended_ack: 0 # Allow extended ACK states (FACK, SACK, DSACK)
+hard_net_allow_extended_ack: 0
+# @var hard_net_allow_ip_forward: 0 # Allow IP forwarding (routing)
+hard_net_allow_ip_forward: 0
+# @var hard_net_allow_reverse_path: 1 # Disallow reverse path
+hard_net_allow_reverse_path: 1
+# @var hard_net_log_martians: 1 # Enable martians packets logging
+hard_net_log_martians: 1
+# @var hard_net_ignore_icmp_not_rfc1122: 1 # Ignore non RFC1122 ICMP packets
+hard_net_ignore_icmp_not_rfc1122: 1
+# @var hard_net_ephemeral_port_range: '32768 65535' # Specify ephemeral port range
+hard_net_ephemeral_port_range: '32768 65535'
+# @var hard_net_enable_rs: 0 # Allow router solicitation support
+hard_net_allow_rs: 0
+# @var hard_net_allow_ra_rtr_pref: 0 # Allow "router preferences" by "router advertisements "
+hard_net_allow_ra_rtr_pref: 0
+# @var hard_net_allow_ra_prefix_autoconf: 0 # Allow prefix autoconfiguration from RA
+hard_net_allow_ra_prefix_autoconf: 0
+# @var hard_net_allow_ra_defroute: 0 # Allow router advertisement default route
+hard_net_allow_ra_defroute: 0
+# @var hard_net_allow_ra_autoconf: 0 # Allow RA autoconfiguration
+hard_net_allow_ra_autoconf: 0

--- a/tasks/hardening/kernel.yml
+++ b/tasks/hardening/kernel.yml
@@ -1,0 +1,78 @@
+---
+- name: "kernel | tune kernel self protection"
+  ansible.posix.sysctl:
+    name: 'kernel.kptr_restrict'
+    value: "{{hard_kernel_self_protection}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_kernel_sysctl_file}}"
+    state: present
+    reload: yes
+
+- name: "kernel | tune dmesg restriction"
+  ansible.posix.sysctl:
+    name: 'kernel.dmesg_restrict'
+    value: "{{hard_kernel_dmesg_restrict}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_kernel_sysctl_file}}"
+    state: present
+    reload: yes
+
+- name: "kernel | tune eBPF calls"
+  ansible.posix.sysctl:
+    name: "{{item.pointer}}"
+    value: "{{item.data}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_kernel_sysctl_file}}"
+    state: present
+    reload: yes
+  with_items:
+    - { pointer: 'kernel.unprivileged_bpf_disabled', data: "{{hard_kernel_disable_unpriv_bpf}}" }
+    - { pointer: 'net.core.bpf_jit_harden', data: "{{hard_net_disable_unpriv_bpf}}" }
+
+- name: "kernel | stat if line discipline endpoint exist"
+  ansible.builtin.stat:
+    path: '/proc/sys/dev/tty/ldisc_autoload'
+  register: dev_tty_ldisc_autoload_endpoint
+
+- name: "kernel | tune line discipline autoload"
+  ansible.posix.sysctl:
+    name: 'dev.tty.ldisc_autoload'
+    value: "{{hard_dev_enable_ldisc_autoload}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_kernel_sysctl_file}}"
+    state: present
+    reload: yes
+  when: dev_tty_ldisc_autoload_endpoint.stat.exists
+
+- name: "kernel | stat if unprivileged syscall endpoint exist"
+  ansible.builtin.stat:
+    path: '/proc/sys/vm/unprivileged_userfaultfd'
+  register: vm_unprivileged_userfaultfd_endpoint
+
+- name: "kernel | tune unprivileged syscall userfaultfd"
+  ansible.posix.sysctl:
+    name: 'vm.unprivileged_userfaultfd'
+    value: "{{hard_vm_enable_unpriv_userfaultfd}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_kernel_sysctl_file}}"
+    state: present
+    reload: yes
+  when: vm_unprivileged_userfaultfd_endpoint.stat.exists
+
+- name: "kernel | tune kexec hability"
+  ansible.posix.sysctl:
+    name: 'kernel.kexec_load_disabled'
+    value: "{{hard_kernel_disable_kexec}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_kernel_sysctl_file}}"
+    state: present
+    reload: yes
+
+- name: "kernel | tune sysrq"
+  ansible.posix.sysctl:
+    name: 'kernel.sysrq'
+    value: "{{hard_kernel_sysrq}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_kernel_sysctl_file}}"
+    state: present
+    reload: yes

--- a/tasks/hardening/network.yml
+++ b/tasks/hardening/network.yml
@@ -1,0 +1,133 @@
+---
+- name: "hardening | network | tune TCP SYN cookies"
+  ansible.posix.sysctl:
+    name: 'net.ipv4.tcp_syncookies'
+    value: "{{hard_net_tcp_syncookies}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+
+- name: "hardening | network | tune TCP RFC1337"
+  ansible.posix.sysctl:
+    name: 'net.ipv4.tcp_rfc1337'
+    value: "{{hard_net_tcp_rfc1337}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+
+- name: "hardening | network | tune source packet validation"
+  ansible.posix.sysctl:
+    name: "{{item.pointer}}"
+    value: "{{item.data}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+  with_items:
+    - { pointer: 'net.ipv4.conf.all.rp_filter', data: "{{hard_net_pkt_validation}}" }
+    - { pointer: 'net.ipv4.conf.default.rp_filter', data: "{{hard_net_pkt_validation}}" }
+
+- name: "hardening | network | tune ICMP redirect acceptance and sending"
+  ansible.posix.sysctl:
+    name: "{{item.pointer}}"
+    value: "{{item.data}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+  with_items:
+    - { pointer: 'net.ipv4.conf.all.accept_redirects', data: "{{hard_net_accept_icmp_redirect}}" }
+    - { pointer: 'net.ipv4.conf.default.accept_redirects', data: "{{hard_net_accept_icmp_redirect}}" }
+    - { pointer: 'net.ipv4.conf.all.secure_redirects', data: "{{hard_net_accept_icmp_redirect}}" }
+    - { pointer: 'net.ipv4.conf.default.secure_redirects', data: "{{hard_net_accept_icmp_redirect}}" }
+    - { pointer: 'net.ipv4.conf.all.send_redirects', data: "{{hard_net_accept_icmp_redirect}}" }
+    - { pointer: 'net.ipv4.conf.default.send_redirects', data: "{{hard_net_accept_icmp_redirect}}" }
+    - { pointer: 'net.ipv6.conf.all.accept_redirects', data: "{{hard_net_accept_icmp_redirect}}" }
+    - { pointer: 'net.ipv6.conf.default.accept_redirects', data: "{{hard_net_accept_icmp_redirect}}" }
+
+- name: "hardening | network | tune ICMP echo request acceptation"
+  ansible.posix.sysctl:
+    name: 'net.ipv4.icmp_echo_ignore_all'
+    value: "{{hard_net_ignore_icmp_echo}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+
+- name: "hardening | network | tune source routing acceptation"
+  ansible.posix.sysctl:
+    name: "{{item.pointer}}"
+    value: "{{item.data}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+  with_items:
+    - { pointer: 'net.ipv4.conf.all.accept_source_route', data: "{{hard_net_allow_source_routing}}" }
+    - { pointer: 'net.ipv4.conf.default.accept_source_route', data: "{{hard_net_allow_source_routing}}" }
+    - { pointer: 'net.ipv6.conf.all.accept_source_route', data: "{{hard_net_allow_source_routing}}" }
+    - { pointer: 'net.ipv6.conf.default.accept_source_route', data: "{{hard_net_allow_source_routing}}" }
+
+- name: "hardening | network | tune extended ACK states acceptance"
+  ansible.posix.sysctl:
+    name: "{{item.pointer}}"
+    value: "{{item.data}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+  with_items:
+    - { pointer: 'net.ipv4.tcp_sack', data: "{{hard_net_allow_extended_ack}}" }
+    - { pointer: 'net.ipv4.tcp_dsack', data: "{{hard_net_allow_extended_ack}}" }
+    - { pointer: 'net.ipv4.tcp_fack', data: "{{hard_net_allow_extended_ack}}" }
+
+- name: "hardening | network | tune martians packets logging"
+  ansible.posix.sysctl:
+    name: 'net.ipv4.conf.all.log_martians'
+    value: "{{hard_net_log_martians}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+
+- name: "hardening | network | tune icmp not rfc1122 ignore"
+  ansible.posix.sysctl:
+    name: 'net.ipv4.icmp_ignore_bogus_error_responses'
+    value: "{{hard_net_ignore_icmp_not_rfc1122}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+
+- name: "hardening | network | tune ephemeral port range"
+  ansible.posix.sysctl:
+    name: 'net.ipv4.ip_local_port_range'
+    value: "{{hard_net_ephemeral_port_range}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+
+- name: "hardening | network | tune router advertisement acceptation"
+  ansible.posix.sysctl:
+    name: "{{item.pointer}}"
+    value: "{{item.data}}"
+    sysctl_set: yes
+    sysctl_file: "{{hardening_network_sysctl_file}}"
+    state: present
+    reload: yes
+  with_items:
+    - { pointer: 'net.ipv6.conf.all.accept_ra', data: "{{hard_net_allow_ra}}" }
+    - { pointer: 'net.ipv6.conf.default.accept_ra', data: "{{hard_net_allow_ra}}" }
+    - { pointer: 'net.ipv6.conf.all.router_solicitations', data: "{{hard_net_allow_rs}}" }
+    - { pointer: 'net.ipv6.conf.default.router_solicitations', data: "{{hard_net_allow_rs}}" }
+    - { pointer: 'net.ipv6.conf.all.accept_ra_rtr_pref', data: "{{hard_net_allow_ra_rtr_pref}}" }
+    - { pointer: 'net.ipv6.conf.default.accept_ra_rtr_pref', data: "{{hard_net_allow_ra_rtr_pref}}" }
+    - { pointer: 'net.ipv6.conf.all.accept_ra_pinfo', data: "{{hard_net_allow_ra_prefix_autoconf}}" }
+    - { pointer: 'net.ipv6.conf.default.accept_ra_pinfo', data: "{{hard_net_allow_ra_prefix_autoconf}}" }
+    - { pointer: 'net.ipv6.conf.all.accept_ra_defrtr', data: "{{hard_net_allow_ra_defroute}}" }
+    - { pointer: 'net.ipv6.conf.default.accept_ra_defrtr', data: "{{hard_net_allow_ra_defroute}}" }
+    - { pointer: 'net.ipv6.conf.all.autoconf', data: "{{hard_net_allow_ra_autoconf}}" }
+    - { pointer: 'net.ipv6.conf.default.autoconf', data: "{{hard_net_allow_ra_autoconf}}" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,11 @@
 - name: 'import kernel hardening'
   ansible.builtin.import_tasks: 'hardening/kernel.yml'
   when: kernel_hardening
+  tags:
+    - configure
 
 - name: 'import network hardening'
   ansible.builtin.import_tasks: 'hardening/network.yml'
   when: network_hardening
+  tags:
+    - configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,3 +8,11 @@
 - name: 'import openssh'
   ansible.builtin.import_tasks: 'openssh/main.yml'
   when: openssh_config
+
+- name: 'import kernel hardening'
+  ansible.builtin.import_tasks: 'hardening/kernel.yml'
+  when: kernel_hardening
+
+- name: 'import network hardening'
+  ansible.builtin.import_tasks: 'hardening/network.yml'
+  when: network_hardening

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,6 @@
 ---
 sshd_config_path: '/etc/ssh/sshd_config'
 ssh_config_path: '/etc/ssh/ssh_config'
+
+hardening_kernel_sysctl_file: '/etc/sysctl.d/00-ansible_kernel_hardening.conf'
+hardening_network_sysctl_file: '/etc/sysctl.d/00-ansible_network_hardening.conf'


### PR DESCRIPTION
# Feature

- Enable kernel self protection
- Restrict dmesg access
- Restrict unprivileged BPF
- Restrict line discipline
- Restrict userfaultfd system call
- Disable kexec
- Lowering sysrq hability
- Enable TCP SYN cookies
- Drop TIME-WAIT connections
- Force packet source validation
- Deny ICMP redirect
- Deny source routing
- Disable all IPv6 RA stack
- Disable TCP extended ACK (FACK, SACK, DSACK)
- Disable IP Forwarding
- Deny reverse path
- Enable martians packets logging
- Ignore non RFC1122 ICMP packets
